### PR TITLE
Fix kgl examples

### DIFF
--- a/gl-pvr.c
+++ b/gl-pvr.c
@@ -31,6 +31,9 @@
 #include "gl-sh4.h"
 #include "gl-pvr.h"
 
+#define QACR0 (*(volatile unsigned long *)(void *)0xff000038)
+#define QACR1 (*(volatile unsigned long *)(void *)0xff00003c)
+
 /* Vertex Buffer Functions *************************************************************************/
 
 #ifdef GL_KOS_USE_MALLOC
@@ -55,7 +58,7 @@ static GLuint             GL_MTOBJECTS = 0;
 
 /* Custom version of sq_cpy from KOS for copying vertex data to the PVR */
 static inline void pvr_list_submit(void *src, int n) {
-    GLuint *d = TA_SQ_ADDR;
+    GLuint *d = SQ_MASK_DEST_ADDR(PVR_TA_INPUT);
     GLuint *s = src;
 
     /* fill/write queues as many times necessary */
@@ -80,7 +83,7 @@ static inline void pvr_list_submit(void *src, int n) {
 
 /* Custom version of sq_cpy from KOS for copying 32bytes of vertex data to the PVR */
 static inline void pvr_hdr_submit(const GLuint *src) {
-    GLuint *d = TA_SQ_ADDR;
+    GLuint *d = SQ_MASK_DEST_ADDR(PVR_TA_INPUT);
 
     d[0] = *(src++);
     d[1] = *(src++);

--- a/gl-pvr.c
+++ b/gl-pvr.c
@@ -58,7 +58,7 @@ static GLuint             GL_MTOBJECTS = 0;
 
 /* Custom version of sq_cpy from KOS for copying vertex data to the PVR */
 static inline void pvr_list_submit(void *src, int n) {
-    GLuint *d = SQ_MASK_DEST_ADDR(PVR_TA_INPUT);
+    GLuint *d = TA_SQ_ADDR;
     GLuint *s = src;
 
     /* fill/write queues as many times necessary */
@@ -83,7 +83,7 @@ static inline void pvr_list_submit(void *src, int n) {
 
 /* Custom version of sq_cpy from KOS for copying 32bytes of vertex data to the PVR */
 static inline void pvr_hdr_submit(const GLuint *src) {
-    GLuint *d = SQ_MASK_DEST_ADDR(PVR_TA_INPUT);
+    GLuint *d = TA_SQ_ADDR;
 
     d[0] = *(src++);
     d[1] = *(src++);
@@ -208,7 +208,8 @@ inline void _glKosVertexBufCopy(void *dst, void *src, GLuint count) {
 
 static inline void glutSwapBuffer() {
 #ifndef GL_KOS_USE_DMA
-    sq_lock(PVR_TA_INPUT);
+    QACR0 = QACRTA;
+    QACR1 = QACRTA;
 #endif
 
     pvr_list_begin(PVR_LIST_OP_POLY);
@@ -257,10 +258,6 @@ static inline void glutSwapBuffer() {
     pvr_list_finish();
 
     pvr_scene_finish();
-
-#ifndef GL_KOS_USE_DMA
-    sq_unlock();
-#endif
 }
 
 void glutSwapBuffers() {

--- a/gl-pvr.c
+++ b/gl-pvr.c
@@ -53,7 +53,6 @@ static GLuint GL_VERTS[2] = {0, 0},
 static GL_MULTITEX_OBJECT GL_MTOBJS[GL_KOS_MAX_MULTITEXTURE_OBJECTS];
 static GLuint             GL_MTOBJECTS = 0;
 
-#if 0
 /* Custom version of sq_cpy from KOS for copying vertex data to the PVR */
 static inline void pvr_list_submit(void *src, int n) {
     GLuint *d = TA_SQ_ADDR;
@@ -94,12 +93,6 @@ static inline void pvr_hdr_submit(const GLuint *src) {
 
     asm("pref @%0" : : "r"(d));
 }
-#else
-
-#define pvr_list_submit(src, n) sq_cpy(TA_SQ_ADDR, (src), ((n) << 5))
-#define pvr_hdr_submit(src) sq_cpy(TA_SQ_ADDR, (src), 32)
-
-#endif
 
 inline void _glKosPushMultiTexObject(GL_TEXTURE_OBJECT *tex,
                                      pvr_vertex_t *src,
@@ -212,10 +205,8 @@ inline void _glKosVertexBufCopy(void *dst, void *src, GLuint count) {
 
 static inline void glutSwapBuffer() {
 #ifndef GL_KOS_USE_DMA
-#if 0
     QACR0 = QACRTA;
     QACR1 = QACRTA;
-#endif
 #endif
 
     pvr_list_begin(PVR_LIST_OP_POLY);

--- a/gl-pvr.c
+++ b/gl-pvr.c
@@ -31,6 +31,9 @@
 #include "gl-sh4.h"
 #include "gl-pvr.h"
 
+#define QACR0 (*(volatile unsigned long *)(void *)0xff000038)
+#define QACR1 (*(volatile unsigned long *)(void *)0xff00003c)
+
 /* Vertex Buffer Functions *************************************************************************/
 
 #ifdef GL_KOS_USE_MALLOC

--- a/gl-pvr.c
+++ b/gl-pvr.c
@@ -31,9 +31,6 @@
 #include "gl-sh4.h"
 #include "gl-pvr.h"
 
-#define QACR0 (*(volatile unsigned long *)(void *)0xff000038)
-#define QACR1 (*(volatile unsigned long *)(void *)0xff00003c)
-
 /* Vertex Buffer Functions *************************************************************************/
 
 #ifdef GL_KOS_USE_MALLOC
@@ -208,8 +205,7 @@ inline void _glKosVertexBufCopy(void *dst, void *src, GLuint count) {
 
 static inline void glutSwapBuffer() {
 #ifndef GL_KOS_USE_DMA
-    QACR0 = QACRTA;
-    QACR1 = QACRTA;
+    sq_lock(PVR_TA_INPUT);
 #endif
 
     pvr_list_begin(PVR_LIST_OP_POLY);
@@ -258,6 +254,10 @@ static inline void glutSwapBuffer() {
     pvr_list_finish();
 
     pvr_scene_finish();
+
+#ifndef GL_KOS_USE_DMA
+    sq_unlock();
+#endif
 }
 
 void glutSwapBuffers() {

--- a/gl-pvr.h
+++ b/gl-pvr.h
@@ -37,8 +37,6 @@ typedef struct {
 #define TA_SQ_ADDR (unsigned int *)(void *) \
     (0xe0000000 | (((unsigned long)0x10000000) & 0x03ffffe0))
 
-#define QACR0 (*(volatile unsigned long *)(void *)0xff000038)
-#define QACR1 (*(volatile unsigned long *)(void *)0xff00003c)
 #define QACRTA ((((unsigned int)0x10000000)>>26)<<2)&0x1c
 
 #define PVR_TA_TXR_FILTER_SHIFT     14

--- a/gl-pvr.h
+++ b/gl-pvr.h
@@ -37,6 +37,8 @@ typedef struct {
 #define TA_SQ_ADDR (unsigned int *)(void *) \
     (0xe0000000 | (((unsigned long)0x10000000) & 0x03ffffe0))
 
+#define QACR0 (*(volatile unsigned long *)(void *)0xff000038)
+#define QACR1 (*(volatile unsigned long *)(void *)0xff00003c)
 #define QACRTA ((((unsigned int)0x10000000)>>26)<<2)&0x1c
 
 #define PVR_TA_TXR_FILTER_SHIFT     14


### PR DESCRIPTION
Fix kgl examples by declaring the SQ registers macros in the gl-pvr.c file.  Using the new SQ api doesnt seem to work here.